### PR TITLE
Do not pass "null" to stream_filter_append

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ can do about this in this library.
 [Our test suite](tests/) contains several test cases that exhibit these issues.
 If you feel some test case is missing or outdated, we're happy to accept PRs! :)
 
+##### Warning
+
+There is different behavior of this function depending how many arguments you use. 
+`fun($filter)` and `fun($filter, null)` does not necessarily give the same result. 
+This strange behavior is copied from the underlying API of `stream_filter_append`.
+Generally, it is a good idea to never pass `null` as second parameter.  
+
 ### remove()
 
 The `remove($filter)` function can be used to

--- a/src/functions.php
+++ b/src/functions.php
@@ -51,6 +51,8 @@ function prepend($stream, $callback, $read_write = STREAM_FILTER_ALL)
 /**
  * Creates filter fun (function) which uses the given built-in $filter
  *
+ * WARNING: Take note that fun($filter) and fun($filter, null) have different behaviors.
+ *
  * @param string $filter built-in filter name, see stream_get_filters()
  * @param mixed  $params additional parameters to pass to the built-in filter
  * @return callable a filter callback which can be append()'ed or prepend()'ed

--- a/src/functions.php
+++ b/src/functions.php
@@ -61,7 +61,11 @@ function prepend($stream, $callback, $read_write = STREAM_FILTER_ALL)
 function fun($filter, $params = null)
 {
     $fp = fopen('php://memory', 'w');
-    $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE, $params);
+    if (null === $params) {
+        $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE);
+    } else {
+        $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE, $params);
+    }
 
     if ($filter === false) {
         fclose($fp);

--- a/src/functions.php
+++ b/src/functions.php
@@ -61,7 +61,7 @@ function prepend($stream, $callback, $read_write = STREAM_FILTER_ALL)
 function fun($filter, $params = null)
 {
     $fp = fopen('php://memory', 'w');
-    if (null === $params) {
+    if (func_num_args() === 1) {
         $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE);
     } else {
         $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE, $params);

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -13,6 +13,16 @@ class FunTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(null, $rot());
     }
 
+    public function testFunInQuotedPrintable()
+    {
+        $encode = Filter\fun('convert.quoted-printable-encode');
+        $decode = Filter\fun('convert.quoted-printable-decode');
+
+        $this->assertEquals('t=C3=A4st', $encode('täst'));
+        $this->assertEquals('täst', $decode($encode('täst')));
+        $this->assertEquals(null, $encode());
+    }
+
     /**
      * @expectedException RuntimeException
      */


### PR DESCRIPTION
Some filters do not support `null` being passed. Their default values are an empty array or nothing. 

If you run the test without the patch you would get: 

```php
1) FunTest::testFunInQuotedPrintable
RuntimeException: Unable to access built-in filter: stream_filter_append(): unable to create or locate filter "convert.quoted-printable-encode"

/path/php-stream-filter/src/functions.php:73
/path/php-stream-filter/tests/FunTest.php:18
```

See the original issue here: https://github.com/php-http/message/issues/78