### PR TITLE
Adding test with base64 encode

### DIFF
--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -34,18 +34,18 @@ class FunTest extends PHPUnit_Framework_TestCase
 
     public function testFunInBase64()
     {
-        $encode = Filter\fun('convert.base64-encode', []);
-        $decode = Filter\fun('convert.base64-decode', []);
+        $encode = Filter\fun('convert.base64-encode', array());
+        $decode = Filter\fun('convert.base64-decode', array());
 
         $string = 'test';
         $this->assertEquals(base64_encode($string), $encode($string) . $encode());
         $this->assertEquals($string, $decode(base64_encode($string)));
 
-        $encode = Filter\fun('convert.base64-encode', []);
-        $decode = Filter\fun('convert.base64-decode', []);
+        $encode = Filter\fun('convert.base64-encode', array());
+        $decode = Filter\fun('convert.base64-decode', array());
         $this->assertEquals($string, $decode($encode($string) . $encode()));
 
-        $encode = Filter\fun('convert.base64-encode', []);
+        $encode = Filter\fun('convert.base64-encode', array());
         $this->assertEquals(null, $encode());
     }
 }

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -31,4 +31,16 @@ class FunTest extends PHPUnit_Framework_TestCase
     {
         Filter\fun('unknown');
     }
+
+    public function testFunInBase64()
+    {
+        $encode = Filter\fun('convert.base64-encode', []);
+        $decode = Filter\fun('convert.base64-decode', []);
+
+        $string = 'test';
+        $this->assertEquals(base64_encode($string), $encode($string));
+        $this->assertEquals($string, $decode(base64_encode($string)));
+        $this->assertEquals($string, $decode($encode($string)));
+        $this->assertEquals(null, $encode());
+    }
 }

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -38,9 +38,14 @@ class FunTest extends PHPUnit_Framework_TestCase
         $decode = Filter\fun('convert.base64-decode', []);
 
         $string = 'test';
-        $this->assertEquals(base64_encode($string), $encode($string));
+        $this->assertEquals(base64_encode($string), $encode($string) . $encode());
         $this->assertEquals($string, $decode(base64_encode($string)));
-        $this->assertEquals($string, $decode($encode($string)));
+
+        $encode = Filter\fun('convert.base64-encode', []);
+        $decode = Filter\fun('convert.base64-decode', []);
+        $this->assertEquals($string, $decode($encode($string) . $encode()));
+
+        $encode = Filter\fun('convert.base64-encode', []);
         $this->assertEquals(null, $encode());
     }
 }


### PR DESCRIPTION
Im not sure why this test fails... I want some help to solve this...

```
1) FunTest::testFunInBase64
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'dGVzdA=='
+'dGVz'

/path/php-stream-filter/tests/FunTest.php:41

```