### PR TITLE
Lock Travis distro so new future defaults will not break the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
   - 7.0
   - 7.1
 
+# lock distro so new future defaults will not break the build
+dist: precise
+
 # also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,21 @@
 language: php
 
 php:
-  - 5.3
+# - 5.3 # requires old distro, see below
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - hhvm # ignore errors, see below
 
 # lock distro so new future defaults will not break the build
-dist: precise
+dist: trusty
 
-# also test against HHVM, but require "trusty" and ignore errors
 matrix:
   include:
-    - php: hhvm
-      dist: trusty
+    - php: 5.3
+      dist: precise
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
Travis is in the process of upgrading the base distro (https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) and despite all PRs currently being "green", will soon start to mark the current master as broken.

While updating the default distro, they also removed support for some older versions of PHP (travis-ci/travis-ci#7163). These versions are still supported by this project, so we now have to explicitly define the base distro to test against.

Builds on top of #14
Originally from clue/php-connection-manager-extra#24