### PR TITLE
Base64 test

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ $ret = $fun('<b>h<br>i</b>');
 assert('<b>hi</b>' === $ret);
 ```
 
+#### Clean the filter function
+
 Under the hood, this function allocates a temporary memory stream, so it's
 recommended to clean up the filter function after use.
 Also, some filter functions (in particular the

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -48,9 +48,14 @@ class FunTest extends PHPUnit_Framework_TestCase
         $decode = Filter\fun('convert.base64-decode', []);
 
         $string = 'test';
-        $this->assertEquals(base64_encode($string), $encode($string));
+        $this->assertEquals(base64_encode($string), $encode($string) . $encode());
         $this->assertEquals($string, $decode(base64_encode($string)));
-        $this->assertEquals($string, $decode($encode($string)));
+
+        $encode = Filter\fun('convert.base64-encode', []);
+        $decode = Filter\fun('convert.base64-decode', []);
+        $this->assertEquals($string, $decode($encode($string) . $encode()));
+
+        $encode = Filter\fun('convert.base64-encode', []);
         $this->assertEquals(null, $encode());
     }
 }

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -41,4 +41,16 @@ class FunTest extends PHPUnit_Framework_TestCase
     {
         Filter\fun('unknown');
     }
+
+    public function testFunInBase64()
+    {
+        $encode = Filter\fun('convert.base64-encode', []);
+        $decode = Filter\fun('convert.base64-decode', []);
+
+        $string = 'test';
+        $this->assertEquals(base64_encode($string), $encode($string));
+        $this->assertEquals($string, $decode(base64_encode($string)));
+        $this->assertEquals($string, $decode($encode($string)));
+        $this->assertEquals(null, $encode());
+    }
 }

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -44,18 +44,18 @@ class FunTest extends PHPUnit_Framework_TestCase
 
     public function testFunInBase64()
     {
-        $encode = Filter\fun('convert.base64-encode', array());
-        $decode = Filter\fun('convert.base64-decode', array());
+        $encode = Filter\fun('convert.base64-encode');
+        $decode = Filter\fun('convert.base64-decode');
 
         $string = 'test';
         $this->assertEquals(base64_encode($string), $encode($string) . $encode());
         $this->assertEquals($string, $decode(base64_encode($string)));
 
-        $encode = Filter\fun('convert.base64-encode', array());
-        $decode = Filter\fun('convert.base64-decode', array());
+        $encode = Filter\fun('convert.base64-encode');
+        $decode = Filter\fun('convert.base64-decode');
         $this->assertEquals($string, $decode($encode($string) . $encode()));
 
-        $encode = Filter\fun('convert.base64-encode', array());
+        $encode = Filter\fun('convert.base64-encode');
         $this->assertEquals(null, $encode());
     }
 }

--- a/tests/FunTest.php
+++ b/tests/FunTest.php
@@ -44,18 +44,18 @@ class FunTest extends PHPUnit_Framework_TestCase
 
     public function testFunInBase64()
     {
-        $encode = Filter\fun('convert.base64-encode', []);
-        $decode = Filter\fun('convert.base64-decode', []);
+        $encode = Filter\fun('convert.base64-encode', array());
+        $decode = Filter\fun('convert.base64-decode', array());
 
         $string = 'test';
         $this->assertEquals(base64_encode($string), $encode($string) . $encode());
         $this->assertEquals($string, $decode(base64_encode($string)));
 
-        $encode = Filter\fun('convert.base64-encode', []);
-        $decode = Filter\fun('convert.base64-decode', []);
+        $encode = Filter\fun('convert.base64-encode', array());
+        $decode = Filter\fun('convert.base64-decode', array());
         $this->assertEquals($string, $decode($encode($string) . $encode()));
 
-        $encode = Filter\fun('convert.base64-encode', []);
+        $encode = Filter\fun('convert.base64-encode', array());
         $this->assertEquals(null, $encode());
     }
 }


### PR DESCRIPTION
This test would have failed in v1.3. I've made the change suggested in https://github.com/clue/php-stream-filter/pull/17#issuecomment-312462531

I also made an extra heading to make it more clear that you have to clean the buffer (as suggested here https://github.com/clue/php-stream-filter/pull/17#issuecomment-312485846).

This will replace #17