### PR TITLE
Check if the function is declared before declaring it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "autoload": {
         "psr-4": { "Clue\\StreamFilter\\": "src/" },
-        "files": [ "src/functions.php" ]
+        "files": [ "src/functions_include.php" ]
     }
 }

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,5 @@
+<?php
+
+if (!function_exists('Clue\\StreamFilter\\append')) {
+    require __DIR__ . '/functions.php';
+}


### PR DESCRIPTION
In case you use pthreads or something else related to threading you might encounter this issue. It happens only with functions and is fixable only by adding these checks. Another way to avoid this is to wrap functions as static into classes.