### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and skip failing tests on PHP 8 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -20,7 +20,8 @@ matrix:
     - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.36"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
     },
     "autoload": {
         "psr-4": { "Clue\\StreamFilter\\": "src/" },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Stream Filter Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Stream Filter Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -337,6 +337,8 @@ class FilterTest extends TestCase
 
     public function testAppendInvalidStreamIsRuntimeError()
     {
+        if (PHP_VERSION >= 8) $this->markTestSkipped('Not supported on PHP 8+ (PHP 8 throws TypeError automatically)');
+
         $this->setExpectedException('RuntimeException');
         if (defined('HHVM_VERSION')) $this->markTestSkipped('Not supported on HHVM (does not reject invalid stream)');
         StreamFilter\append(false, function () { });
@@ -344,6 +346,8 @@ class FilterTest extends TestCase
 
     public function testPrependInvalidStreamIsRuntimeError()
     {
+        if (PHP_VERSION >= 8) $this->markTestSkipped('Not supported on PHP 8+ (PHP 8 throws TypeError automatically)');
+
         $this->setExpectedException('RuntimeException');
         if (defined('HHVM_VERSION')) $this->markTestSkipped('Not supported on HHVM (does not reject invalid stream)');
         StreamFilter\prepend(false, function () { });
@@ -351,6 +355,8 @@ class FilterTest extends TestCase
 
     public function testRemoveInvalidFilterIsRuntimeError()
     {
+        if (PHP_VERSION >= 8) $this->markTestSkipped('Not supported on PHP 8+ (PHP 8 throws TypeError automatically)');
+
         $this->setExpectedException('RuntimeException');
         if (defined('HHVM_VERSION')) $this->markTestSkipped('Not supported on HHVM (does not reject invalid filters)');
         StreamFilter\remove(false);
@@ -403,5 +409,4 @@ class FilterTest extends TestCase
             $this->assertContains($needle, $haystack);
         }
     }
-
 }

--- a/tests/FunZlibTest.php
+++ b/tests/FunZlibTest.php
@@ -5,7 +5,7 @@ namespace Clue\Tests\StreamFilter;
 use Clue\StreamFilter;
 use PHPUnit\Framework\TestCase;
 
-class BuiltInZlibTest extends TestCase
+class FunZlibTest extends TestCase
 {
     public function testFunZlibDeflateHelloWorld()
     {
@@ -18,7 +18,7 @@ class BuiltInZlibTest extends TestCase
 
     public function testFunZlibDeflateEmpty()
     {
-        if (PHP_VERSION >= 7) $this->markTestSkipped('Not supported on PHP7 (empty string does not invoke filter)');
+        if (PHP_VERSION >= 7) $this->markTestSkipped('Not supported on PHP 7+ (empty string does not invoke filter)');
 
         $deflate = StreamFilter\fun('zlib.deflate');
 


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #34.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.3.11 by Sebastian Bergmann and contributors.

................SSS.......S....                                   31 / 31 (100%)

Time: 00:00.007, Memory: 6.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 31, Assertions: 47, Skipped: 4.
```