### PR TITLE
Improve performance by using global imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Alternatively, you can also refer to them with their fully-qualified name:
 \Clue\StreamFilter\append(…);
 ```
 
+As of PHP 5.6+ you can also import each required function into your code like this:
+
+```php
+use function Clue\StreamFilter\append;
+
+append(…);
+```
+
 ### append()
 
 The `append(resource<stream> $stream, callable $callback, int $read_write = STREAM_FILTER_ALL): resource<stream filter>` function can be used to

--- a/src/CallbackFilter.php
+++ b/src/CallbackFilter.php
@@ -2,18 +2,12 @@
 
 namespace Clue\StreamFilter;
 
-use php_user_filter;
-use InvalidArgumentException;
-use ReflectionFunction;
-use Exception;
-
 /**
- *
  * @internal
  * @see append()
  * @see prepend()
  */
-class CallbackFilter extends php_user_filter
+class CallbackFilter extends \php_user_filter
 {
     private $callback;
     private $closed = true;
@@ -23,13 +17,13 @@ class CallbackFilter extends php_user_filter
     {
         $this->closed = false;
 
-        if (!is_callable($this->params)) {
-            throw new InvalidArgumentException('No valid callback parameter given to stream_filter_(append|prepend)');
+        if (!\is_callable($this->params)) {
+            throw new \InvalidArgumentException('No valid callback parameter given to stream_filter_(append|prepend)');
         }
         $this->callback = $this->params;
 
         // callback supports end event if it accepts invocation without arguments
-        $ref = new ReflectionFunction($this->callback);
+        $ref = new \ReflectionFunction($this->callback);
         $this->supportsClose = ($ref->getNumberOfRequiredParameters() === 0);
 
         return true;
@@ -44,8 +38,8 @@ class CallbackFilter extends php_user_filter
             $this->supportsClose = false;
             // invoke without argument to signal end and discard resulting buffer
             try {
-                call_user_func($this->callback);
-            } catch (Exception $ignored) {
+                \call_user_func($this->callback);
+            } catch (\Exception $ignored) {
                 // this might be called during engine shutdown, so it's not safe
                 // to raise any errors or exceptions here
                 // trigger_error('Error closing filter: ' . $ignored->getMessage(), E_USER_WARNING);
@@ -59,27 +53,27 @@ class CallbackFilter extends php_user_filter
     {
         // concatenate whole buffer from input brigade
         $data = '';
-        while ($bucket = stream_bucket_make_writeable($in)) {
+        while ($bucket = \stream_bucket_make_writeable($in)) {
             $consumed += $bucket->datalen;
             $data .= $bucket->data;
         }
 
         // skip processing callback that already ended
         if ($this->closed) {
-            return PSFS_FEED_ME;
+            return \PSFS_FEED_ME;
         }
 
         // only invoke filter function if buffer is not empty
         // this may skip flushing a closing filter
         if ($data !== '') {
             try {
-                $data = call_user_func($this->callback, $data);
-            } catch (Exception $e) {
+                $data = \call_user_func($this->callback, $data);
+            } catch (\Exception $e) {
                 // exception should mark filter as closed
                 $this->onClose();
-                trigger_error('Error invoking filter: ' . $e->getMessage(), E_USER_WARNING);
+                \trigger_error('Error invoking filter: ' . $e->getMessage(), \E_USER_WARNING);
 
-                return PSFS_ERR_FATAL;
+                return \PSFS_ERR_FATAL;
             }
         }
 
@@ -93,11 +87,11 @@ class CallbackFilter extends php_user_filter
 
                 // invoke without argument to signal end and append resulting buffer
                 try {
-                    $data .= call_user_func($this->callback);
-                } catch (Exception $e) {
-                    trigger_error('Error ending filter: ' . $e->getMessage(), E_USER_WARNING);
+                    $data .= \call_user_func($this->callback);
+                } catch (\Exception $e) {
+                    \trigger_error('Error ending filter: ' . $e->getMessage(), \E_USER_WARNING);
 
-                    return PSFS_ERR_FATAL;
+                    return \PSFS_ERR_FATAL;
                 }
             }
         }
@@ -105,16 +99,16 @@ class CallbackFilter extends php_user_filter
         if ($data !== '') {
             // create a new bucket for writing the resulting buffer to the output brigade
             // reusing an existing bucket turned out to be bugged in some environments (ancient PHP versions and HHVM)
-            $bucket = @stream_bucket_new($this->stream, $data);
+            $bucket = @\stream_bucket_new($this->stream, $data);
 
             // legacy PHP versions (PHP < 5.4) do not support passing data from the event signal handler
             // because closing the stream invalidates the stream and its stream bucket brigade before
             // invoking the filter close handler.
             if ($bucket !== false) {
-                stream_bucket_append($out, $bucket);
+                \stream_bucket_append($out, $bucket);
             }
         }
 
-        return PSFS_PASS_ON;
+        return \PSFS_PASS_ON;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,8 +2,6 @@
 
 namespace Clue\StreamFilter;
 
-use RuntimeException;
-
 /**
  * Append a filter callback to the given stream.
  *
@@ -106,13 +104,13 @@ use RuntimeException;
  */
 function append($stream, $callback, $read_write = STREAM_FILTER_ALL)
 {
-    $ret = @stream_filter_append($stream, register(), $read_write, $callback);
+    $ret = @\stream_filter_append($stream, register(), $read_write, $callback);
 
     // PHP 8 throws above on type errors, older PHP and memory issues can throw here
     // @codeCoverageIgnoreStart
     if ($ret === false) {
-        $error = error_get_last() + array('message' => '');
-        throw new RuntimeException('Unable to append filter: ' . $error['message']);
+        $error = \error_get_last() + array('message' => '');
+        throw new \RuntimeException('Unable to append filter: ' . $error['message']);
     }
     // @codeCoverageIgnoreEnd
 
@@ -149,13 +147,13 @@ function append($stream, $callback, $read_write = STREAM_FILTER_ALL)
  */
 function prepend($stream, $callback, $read_write = STREAM_FILTER_ALL)
 {
-    $ret = @stream_filter_prepend($stream, register(), $read_write, $callback);
+    $ret = @\stream_filter_prepend($stream, register(), $read_write, $callback);
 
     // PHP 8 throws above on type errors, older PHP and memory issues can throw here
     // @codeCoverageIgnoreStart
     if ($ret === false) {
-        $error = error_get_last() + array('message' => '');
-        throw new RuntimeException('Unable to prepend filter: ' . $error['message']);
+        $error = \error_get_last() + array('message' => '');
+        throw new \RuntimeException('Unable to prepend filter: ' . $error['message']);
     }
     // @codeCoverageIgnoreEnd
 
@@ -236,24 +234,24 @@ function prepend($stream, $callback, $read_write = STREAM_FILTER_ALL)
  * @param string $filter     built-in filter name. See stream_get_filters() or http://php.net/manual/en/filters.php
  * @param mixed  $parameters (optional) parameters to pass to the built-in filter as-is
  * @return callable a filter callback which can be append()'ed or prepend()'ed
- * @throws RuntimeException on error
+ * @throws \RuntimeException on error
  * @link http://php.net/manual/en/filters.php
  * @see stream_get_filters()
  * @see append()
  */
 function fun($filter, $parameters = null)
 {
-    $fp = fopen('php://memory', 'w');
-    if (func_num_args() === 1) {
-        $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE);
+    $fp = \fopen('php://memory', 'w');
+    if (\func_num_args() === 1) {
+        $filter = @\stream_filter_append($fp, $filter, \STREAM_FILTER_WRITE);
     } else {
-        $filter = @stream_filter_append($fp, $filter, STREAM_FILTER_WRITE, $parameters);
+        $filter = @\stream_filter_append($fp, $filter, \STREAM_FILTER_WRITE, $parameters);
     }
 
     if ($filter === false) {
-        fclose($fp);
-        $error = error_get_last() + array('message' => '');
-        throw new RuntimeException('Unable to access built-in filter: ' . $error['message']);
+        \fclose($fp);
+        $error = \error_get_last() + array('message' => '');
+        throw new \RuntimeException('Unable to access built-in filter: ' . $error['message']);
     }
 
     // append filter function which buffers internally
@@ -263,7 +261,7 @@ function fun($filter, $parameters = null)
 
         // always return empty string in order to skip actually writing to stream resource
         return '';
-    }, STREAM_FILTER_WRITE);
+    }, \STREAM_FILTER_WRITE);
 
     $closed = false;
 
@@ -274,12 +272,12 @@ function fun($filter, $parameters = null)
         if ($chunk === null) {
             $closed = true;
             $buffer = '';
-            fclose($fp);
+            \fclose($fp);
             return $buffer;
         }
         // initialize buffer and invoke filters by attempting to write to stream
         $buffer = '';
-        fwrite($fp, $chunk);
+        \fwrite($fp, $chunk);
 
         // buffer now contains everything the filter function returned
         return $buffer;
@@ -298,15 +296,15 @@ function fun($filter, $parameters = null)
  *
  * @param resource $filter
  * @return bool true on success or false on error
- * @throws RuntimeException on error
+ * @throws \RuntimeException on error
  * @uses stream_filter_remove()
  */
 function remove($filter)
 {
-    if (@stream_filter_remove($filter) === false) {
+    if (@\stream_filter_remove($filter) === false) {
         // PHP 8 throws above on type errors, older PHP and memory issues can throw here
-        $error = error_get_last();
-        throw new RuntimeException('Unable to remove filter: ' . $error['message']);
+        $error = \error_get_last();
+        throw new \RuntimeException('Unable to remove filter: ' . $error['message']);
     }
 }
 
@@ -323,7 +321,7 @@ function register()
     static $registered = null;
     if ($registered === null) {
         $registered = 'stream-callback';
-        stream_filter_register($registered, __NAMESPACE__ . '\CallbackFilter');
+        \stream_filter_register($registered, __NAMESPACE__ . '\CallbackFilter');
     }
     return $registered;
 }

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // @codeCoverageIgnoreStart
-if (!function_exists('Clue\\StreamFilter\\append')) {
+if (!\function_exists('Clue\\StreamFilter\\append')) {
     require __DIR__ . '/functions.php';
 }


### PR DESCRIPTION
This changeset improves performance by using global imports.
This has a noticeable performance impact because global imports require
less opcodes than first checking the local namespace. This optimization
only affects a number of functions, but the change has been applied to
all function calls and global references for consistency reasons.